### PR TITLE
都道府県毎の人口数を状態管理するチェックボックスの一覧作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ npx cypress install # 初回だけ
 yarn cypresse:headeless # e2eテストの実行
 # or
 yarn cypresse
+```
 
 
-### 動作環境
+## 動作環境
 
-# - Nodejs(v19.8.1 or v18.12.1 or v16.18.1)とyarnが必要
+### - Nodejs(v19.8.1 or v18.12.1 or v16.18.1)とyarnが必要
 - Nodejsのバージョンはnvmで適切に変更すること
 
 ## Deploy on Vercel

--- a/README.md
+++ b/README.md
@@ -74,8 +74,12 @@ yarn cypresse
 
 ## 動作環境
 
-### - Nodejs(v19.8.1 or v18.12.1 or v16.18.1)とyarnが必要
-- Nodejsのバージョンはnvmで適切に変更すること
+### prerequirements
+
+- Nodejs(v19.8.1 or v18.12.1 or v16.18.1)
+- yarnが必要
+
+Nodejsのバージョンはnvmで適切に変更すること
 
 ## Deploy on Vercel
 https://yumemi-front-second.vercel.app/

--- a/package.json
+++ b/package.json
@@ -25,24 +25,25 @@
     "next": "13.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-spinners": "^0.13.8",
     "recharts": "2.5.0",
     "recoil": "0.7.7",
     "swr": "2.1.4",
     "typescript": "5.0.4",
-    "zod": "^3.21.4"
+    "zod": "3.21.4"
   },
   "devDependencies": {
     "cypress": "^12.10.0",
     "eslint-config-prettier": "8.8.0",
-    "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-promise": "^6.1.1",
-    "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-security": "^1.7.1",
+    "eslint-plugin-import": "2.27.5",
+    "eslint-plugin-promise": "6.1.1",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "eslint-plugin-security": "1.7.1",
     "eslint-plugin-strict-dependencies": "1.1.0",
-    "eslint-plugin-zod": "^1.4.0",
+    "eslint-plugin-zod": "1.4.0",
     "husky": "8.0.3",
     "lint-staged": "13.2.1",
     "prettier": "2.8.8",
-    "vercel": "^28.20.0"
+    "vercel": "28.20.0"
   }
 }

--- a/src/common/apiCache.ts
+++ b/src/common/apiCache.ts
@@ -1,0 +1,35 @@
+interface CacheData<T> {
+  data: T;
+  timestamp: number;
+}
+
+interface Cache {
+  [key: string]: CacheData<unknown>;
+}
+
+const cache: Cache = {};
+
+const checkCacheExpiration = () => {
+  const expirationTime = Date.now() - 60 * 60 * 1000;
+  Object.keys(cache).forEach(key => {
+    if (cache[key]!.timestamp < expirationTime) {
+      delete cache[key];
+    }
+  });
+};
+
+setInterval(checkCacheExpiration, 60 * 60 * 1000);
+
+export const getFromCache = <T>(cacheKey: string): T | null => {
+  const cachedData = cache[cacheKey];
+
+  if (cachedData && Date.now() - cachedData.timestamp < 15 * 60 * 1000) {
+    return cachedData.data as T;
+  } else {
+    return null;
+  }
+};
+
+export const setToCache = <T>(cacheKey: string, data: T): void => {
+  cache[cacheKey] = { data, timestamp: Date.now() };
+};

--- a/src/common/apiFetch.ts
+++ b/src/common/apiFetch.ts
@@ -1,0 +1,15 @@
+import { getFromCache, setToCache } from './apiCache';
+
+async function apiFetch<T>(url: string): Promise<T> {
+  const cachedResult = getFromCache<T>(url);
+  if (cachedResult) {
+    return cachedResult;
+  }
+
+  const response = await fetch(url);
+  const { result } = await response.json();
+  setToCache(url, result);
+  return result;
+}
+
+export default apiFetch;

--- a/src/common/zodValidation.ts
+++ b/src/common/zodValidation.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export type Prefecture = {
+  prefCode: number;
+  prefName: string;
+};
+
+export const prefectureSchema = z
+  .object({
+    prefCode: z.number(),
+    prefName: z.string(),
+  })
+  .strict();

--- a/src/features/prefList/PrefList.tsx
+++ b/src/features/prefList/PrefList.tsx
@@ -1,0 +1,44 @@
+import { ClipLoader } from 'react-spinners';
+import { useRecoilValue } from 'recoil';
+
+import prefListLogic from './prefListLogic';
+import usePrefectures from './usePrefectures';
+
+import Checkbox from '@/components/Checkbox';
+import { checkedPrefAtom } from '@/stores/atoms';
+
+const PrefList = () => {
+  const checkedPrefs = useRecoilValue(checkedPrefAtom);
+  const { handleCheckboxChange } = prefListLogic();
+  const { prefectures, isLoading, isError } = usePrefectures();
+
+  if (isError) return <div>fetch prefectures Error</div>;
+  if (isLoading) {
+    return (
+      <div className='pref-list__loading'>
+        <ClipLoader color='#000' loading={isLoading} size={50} />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <ul className='pref-list'>
+        {prefectures.map(prefecture => (
+          <li key={prefecture.prefCode}>
+            <Checkbox prefecture={prefecture} onChange={handleCheckboxChange} />
+          </li>
+        ))}
+      </ul>
+      {checkedPrefs.length === 0 && (
+        <div className='pref-list__annotation__container'>
+          <p className='pref-list__annotation'>
+            一つ以上の都道府県を選択してください
+          </p>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default PrefList;

--- a/src/features/prefList/fetchPopulationByPrefCode.ts
+++ b/src/features/prefList/fetchPopulationByPrefCode.ts
@@ -1,0 +1,49 @@
+import axios, { AxiosResponse } from 'axios';
+
+import type { PopulationData } from '@/common/types';
+
+import { getFromCache, setToCache } from '@/common/apiCache';
+type PopulationDataResponse = {
+  result?: {
+    data: {
+      data: PopulationData[];
+    }[];
+  };
+};
+
+type PopulationDataCategory = [
+  total: PopulationData[],
+  young: PopulationData[],
+  working: PopulationData[],
+  elderly: PopulationData[],
+];
+export const fetchPopulationByPrefCode = async (
+  prefCode: string,
+): Promise<PopulationDataCategory> => {
+  const cacheKey = `/api/PopulationByPref/${prefCode}`;
+  const cachedData = getFromCache<PopulationDataCategory>(cacheKey);
+
+  if (cachedData) {
+    return cachedData;
+  } else {
+    const { data }: AxiosResponse<PopulationDataResponse> = await axios.get(
+      `/api/PopulationByPref/${prefCode}`,
+    );
+    if (data.result) {
+      const TotalPopulationData = data.result.data[0]?.data ?? [];
+      const YoungPopulationData = data.result.data[1]?.data ?? [];
+      const WorkingPopulationData = data.result.data[2]?.data ?? [];
+      const ElderyPopulationData = data.result.data[3]?.data ?? [];
+      const populationData: PopulationDataCategory = [
+        TotalPopulationData,
+        YoungPopulationData,
+        WorkingPopulationData,
+        ElderyPopulationData,
+      ];
+      setToCache(cacheKey, populationData);
+      return populationData;
+    } else {
+      return [[], [], [], []];
+    }
+  }
+};

--- a/src/features/prefList/prefListLogic.ts
+++ b/src/features/prefList/prefListLogic.ts
@@ -1,0 +1,8 @@
+const PrefListLogic = () => {
+  const handleCheckboxChange = () => {};
+  return {
+    handleCheckboxChange,
+  };
+};
+
+export default PrefListLogic;

--- a/src/features/prefList/prefListLogic.ts
+++ b/src/features/prefList/prefListLogic.ts
@@ -1,5 +1,93 @@
+import { useCallback } from 'react';
+
+import { produce } from 'immer';
+import { useRecoilState, useSetRecoilState, useRecoilValue } from 'recoil';
+
+import { fetchPopulationByPrefCode } from './fetchPopulationByPrefCode';
+import { setPopulationByType } from './setPopulationByType';
+
+import {
+  checkedPrefAtom,
+  populationByYearAtoms,
+  prefectureAtom,
+} from '@/stores/atoms';
+
+const {
+  TotalPopulationAtom,
+  YoungPopulationAtom,
+  WorkingPopulationAtom,
+  ElderlyPopulationAtom,
+} = populationByYearAtoms;
+
 const PrefListLogic = () => {
-  const handleCheckboxChange = () => {};
+  const [checkedPrefs, setCheckedPrefs] = useRecoilState(checkedPrefAtom);
+  const prefectures = useRecoilValue(prefectureAtom);
+  const [
+    setTotalPopulation,
+    setYoungPopulation,
+    setWorkingPopulation,
+    setElderlyPopulation,
+  ] = [
+    useSetRecoilState(TotalPopulationAtom),
+    useSetRecoilState(YoungPopulationAtom),
+    useSetRecoilState(WorkingPopulationAtom),
+    useSetRecoilState(ElderlyPopulationAtom),
+  ];
+
+  const handleCheckboxChange = useCallback(
+    async (prefCode: string) => {
+      const isChecked = checkedPrefs.includes(prefCode);
+      const targetPrefecture = prefectures.find(
+        prefecture => String(prefecture.prefCode) === prefCode,
+      );
+
+      setCheckedPrefs(
+        produce(draft => {
+          if (isChecked) {
+            draft.splice(draft.indexOf(prefCode), 1);
+          } else {
+            draft.push(prefCode);
+          }
+        }),
+      );
+
+      const handlePopulationData = async (
+        prefName: string,
+        prefCode: string,
+      ) => {
+        try {
+          const populationDataList = await fetchPopulationByPrefCode(prefCode);
+          const populationSetters = [
+            setTotalPopulation,
+            setYoungPopulation,
+            setWorkingPopulation,
+            setElderlyPopulation,
+          ];
+
+          populationDataList.forEach((data, index) => {
+            const populationSetter = populationSetters[index];
+            if (data.length > 0 && populationSetter) {
+              setPopulationByType(prefName, data, populationSetter);
+            }
+          });
+        } catch (error) {
+          console.error(
+            `Failed to fetch population data for prefCode: ${prefCode}, error: ${error}`,
+          );
+        }
+      };
+      handlePopulationData(targetPrefecture?.prefName!, prefCode);
+    },
+    [
+      checkedPrefs,
+      prefectures,
+      setCheckedPrefs,
+      setElderlyPopulation,
+      setTotalPopulation,
+      setWorkingPopulation,
+      setYoungPopulation,
+    ],
+  );
   return {
     handleCheckboxChange,
   };

--- a/src/features/prefList/setPopulationByType.ts
+++ b/src/features/prefList/setPopulationByType.ts
@@ -1,0 +1,24 @@
+import { produce, Draft } from 'immer';
+
+import type { PopulationByYear, PopulationData } from '@/common/types';
+export const setPopulationByType = (
+  prefName: string,
+  data: PopulationData[],
+  setPopulation: (f: (prev: PopulationByYear[]) => PopulationByYear[]) => void,
+) => {
+  setPopulation((prev: PopulationByYear[]) =>
+    produce(prev, (draft: Draft<PopulationByYear[]>) => {
+      data.forEach(({ year, value }) => {
+        const i = draft.findIndex(prev => prev.year === year);
+        if (i > -1) {
+          draft[i]![prefName] = value;
+        } else {
+          draft.push({
+            year,
+            [prefName]: value,
+          });
+        }
+      });
+    }),
+  );
+};

--- a/src/features/prefList/usePrefectures.ts
+++ b/src/features/prefList/usePrefectures.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+
+import { useRecoilState } from 'recoil';
+import useSWR from 'swr';
+
+import apiFetch from '@/common/apiFetch';
+import { Prefecture } from '@/common/types';
+import { prefectureSchema } from '@/common/zodValidation';
+import { prefectureAtom } from '@/stores/atoms';
+
+const usePrefectures = () => {
+  const [prefectures, setPrefectures] = useRecoilState(prefectureAtom);
+
+  const prefecturesFetcher = async (url: string): Promise<Prefecture[]> => {
+    const result = await apiFetch<Prefecture[]>(url);
+    const validatedResult = result.map((prefecture: Prefecture) =>
+      prefectureSchema.parse(prefecture),
+    );
+    return validatedResult;
+  };
+
+  const { data, error } = useSWR<Prefecture[]>(
+    '/api/PrefectureCode',
+    prefecturesFetcher,
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 60 * 60 * 1000,
+      revalidateOnMount: true,
+    },
+  );
+
+  useEffect(() => {
+    if (data) {
+      setPrefectures(data);
+    }
+  }, [data, setPrefectures]);
+
+  const isLoading = !data && !error;
+  const isError = error !== undefined;
+
+  return {
+    prefectures,
+    isLoading,
+    isError,
+  };
+};
+
+export default usePrefectures;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,16 @@
 import '@/styles/reset.css';
 import '@/styles/index.css';
+
+import { RecoilRoot } from 'recoil';
+
 import type { AppProps } from 'next/app';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <RecoilRoot>
+        <Component {...pageProps} />
+      </RecoilRoot>
+    </>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,11 @@
 import Header from '@/components/layouts/Header';
+import PrefList from '@/features/prefList/PrefList';
 
 export default function Home() {
   return (
     <>
       <Header />
+      <PrefList />
     </>
   );
 }

--- a/src/stores/atoms.ts
+++ b/src/stores/atoms.ts
@@ -1,0 +1,4 @@
+import { checkedPrefAtom } from './checkedPrefAtom';
+import { prefectureAtom } from './prefectureAtom';
+
+export { prefectureAtom, checkedPrefAtom };

--- a/src/stores/atoms.ts
+++ b/src/stores/atoms.ts
@@ -1,4 +1,5 @@
 import { checkedPrefAtom } from './checkedPrefAtom';
+import { populationByYearAtoms } from './populationByYearAtoms';
 import { prefectureAtom } from './prefectureAtom';
 
-export { prefectureAtom, checkedPrefAtom };
+export { prefectureAtom, checkedPrefAtom, populationByYearAtoms };

--- a/src/stores/checkedPrefAtom.ts
+++ b/src/stores/checkedPrefAtom.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 
 export const checkedPrefAtom = atom<string[]>({
-  key: 'checkedPrefState',
+  key: 'checkedPrefAtom',
   default: [] as string[],
 });

--- a/src/stores/checkedPrefAtom.ts
+++ b/src/stores/checkedPrefAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const checkedPrefAtom = atom<string[]>({
+  key: 'checkedPrefState',
+  default: [] as string[],
+});

--- a/src/stores/populationByYearAtoms.ts
+++ b/src/stores/populationByYearAtoms.ts
@@ -1,0 +1,15 @@
+import { atomFamily } from 'recoil';
+
+import type { PopulationByYear } from '@/common/types';
+
+const populationByYearAtomFamily = atomFamily<PopulationByYear[], string>({
+  key: 'populationByYearAtom',
+  default: [],
+});
+
+export const populationByYearAtoms = {
+  TotalPopulationAtom: populationByYearAtomFamily('TotalPopulation'),
+  YoungPopulationAtom: populationByYearAtomFamily('YoungPopulation'),
+  WorkingPopulationAtom: populationByYearAtomFamily('WorkingPopulation'),
+  ElderlyPopulationAtom: populationByYearAtomFamily('ElderlyPopulation'),
+};

--- a/src/stores/prefectureAtom.ts
+++ b/src/stores/prefectureAtom.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+
+import type { Prefecture } from '@/common/types';
+export const prefectureAtom = atom<Prefecture[]>({
+  key: 'prefectures',
+  default: [],
+});

--- a/src/stores/prefectureAtom.ts
+++ b/src/stores/prefectureAtom.ts
@@ -2,6 +2,6 @@ import { atom } from 'recoil';
 
 import type { Prefecture } from '@/common/types';
 export const prefectureAtom = atom<Prefecture[]>({
-  key: 'prefectures',
+  key: 'prefectureAtom',
   default: [],
 });

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -11,3 +11,54 @@
   color: #eee;
   font-size: clamp(10px, 5vw, 40px);
 }
+
+.pref-list {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(80px, 150px));
+  gap: 10px 80px;
+  justify-content: center;
+}
+
+.pref-list__loading {
+  display: flex;
+  justify-content: center;
+  height: 45vh;
+}
+
+.pref-list__checkbox {
+  position: relative;
+  padding-left: 28px;
+  font-size: clamp(1rem, 2vw, 20px);
+  cursor: pointer;
+  user-select: none;
+  &:hover,
+  &:focus {
+    background-color: #bfbfbf;
+    transform: scale(1.05);
+  }
+}
+
+.pref-list__annotation__container {
+  display: flex;
+  justify-content: center;
+}
+
+.pref-list__annotation {
+  font-size: clamp(1rem, 2vw, 24px);
+  font-weight: bold;
+  color: #555555;
+  user-select: none;
+}
+
+@media screen and (max-width: 800px) {
+  .pref-list {
+    gap: 5px;
+    grid-template-columns: repeat(3, minmax(80px, 150px));
+  }
+  .recharts-default-legend li {
+    font-size: clamp(10px, 5vw, 12px);
+  }
+  .recharts-cartesian-axis-ticks {
+    font-size: clamp(10px, 5vw, 12px);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3906,7 +3906,7 @@ eslint-module-utils@^2.7.4:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@^2.26.0, eslint-plugin-import@^2.27.5:
+eslint-plugin-import@2.27.5, eslint-plugin-import@^2.26.0:
   version "2.27.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz#876a6d03f52608a3e5bb439c2550588e51dd6c65"
   integrity sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==
@@ -3949,12 +3949,12 @@ eslint-plugin-jsx-a11y@^6.5.1:
     object.fromentries "^2.0.6"
     semver "^6.3.0"
 
-eslint-plugin-promise@^6.1.1:
+eslint-plugin-promise@6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz#269a3e2772f62875661220631bd4dafcb4083816"
   integrity sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==
 
-eslint-plugin-react-hooks@^4.5.0, eslint-plugin-react-hooks@^4.6.0:
+eslint-plugin-react-hooks@4.6.0, eslint-plugin-react-hooks@^4.5.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
@@ -3980,7 +3980,7 @@ eslint-plugin-react@^7.31.7:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
 
-eslint-plugin-security@^1.7.1:
+eslint-plugin-security@1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-security/-/eslint-plugin-security-1.7.1.tgz#0e9c4a471f6e4d3ca16413c7a4a51f3966ba16e4"
   integrity sha512-sMStceig8AFglhhT2LqlU5r+/fn9OwsA72O5bBuQVTssPCdQAOQzL+oMn/ZcpeUY6KcNfLJArgcrsSULNjYYdQ==
@@ -3997,7 +3997,7 @@ eslint-plugin-strict-dependencies@1.1.0:
     normalize-path "^3.0.0"
     require-strip-json-comments "^2.0.0"
 
-eslint-plugin-zod@^1.4.0:
+eslint-plugin-zod@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-zod/-/eslint-plugin-zod-1.4.0.tgz#02032d4947581ce35e068cf5f089010d9669492a"
   integrity sha512-i9WzQGw2X5fQcuQh33mA8DQjZJM/yuyZvs1Fc5EyTidX7Ed/g832+1FEQ4u5gtXy+jZ+DVsB5+oMHj4tIOfeZg==
@@ -7148,6 +7148,11 @@ react-smooth@^2.0.2:
     fast-equals "^4.0.3"
     react-transition-group "2.9.0"
 
+react-spinners@^0.13.8:
+  version "0.13.8"
+  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.13.8.tgz#5262571be0f745d86bbd49a1e6b49f9f9cb19acc"
+  integrity sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==
+
 react-transition-group@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
@@ -8427,7 +8432,7 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vercel@^28.20.0:
+vercel@28.20.0:
   version "28.20.0"
   resolved "https://registry.yarnpkg.com/vercel/-/vercel-28.20.0.tgz#cb0ad28c6f07ee7c44e5c6f0ae0c611f6c5467f6"
   integrity sha512-U+ZDKVVgxJyUJ26l/B7o53EeocP4PnbCt7D6Qyt/bI/eJ9BXpBtsWtMJf1CvgH3Iv/QRXFYlCvjHQJLs1BC7qw==
@@ -8708,7 +8713,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.21.4:
+zod@3.21.4:
   version "3.21.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
   integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
# 概要
close #3 

# 変更内容
- recoilを用いて人口タイプ別の人口をrechartsのデータ形式に合う形で状態管理を行う
- apiのリクエスト結果はキャッシュ機能を用い、一定期間内で同じgetリクエストを行わない
- チェックした都道府県だけグラフで表示するようにチェックした都道府県だけを保持する状態をrecoilで管理

# 影響範囲
なし

# 補足
ロジックが少し複雑だが機能的凝集を意識して可読性は高いはずである